### PR TITLE
Overhaul types to better describe package functionality

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -16,12 +16,12 @@
   "index.iife.js": {
     "bundled": 642,
     "minified": 281,
-    "gzipped": 201
+    "gzipped": 203
   },
   "loadable.js": {
-    "bundled": 332,
+    "bundled": 277,
     "minified": 165,
-    "gzipped": 150,
+    "gzipped": 152,
     "treeshaked": {
       "rollup": {
         "code": 28,
@@ -35,10 +35,10 @@
   "index.cjs.js": {
     "bundled": 517,
     "minified": 288,
-    "gzipped": 209
+    "gzipped": 210
   },
   "loadable.cjs.js": {
-    "bundled": 746,
+    "bundled": 691,
     "minified": 450,
     "gzipped": 272
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-lazily",
   "private": true,
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "React.lazy wrapper that works with allows you to destruct imported module, so it will work with non default exports",
   "main": "index.cjs.js",
   "module": "index.js",
@@ -91,6 +91,7 @@
     "@rollup/plugin-typescript": "^6.1.0",
     "@testing-library/react": "^11.2.2",
     "@types/jest": "^26.0.15",
+    "@types/loadable__component": "^5.13.0",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/scheduler": "^0.16.1",
@@ -120,13 +121,17 @@
   "peerDependencies": {
     "react": ">=16.8",
     "react-dom": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "@types/loadable__component": "*"
   },
   "peerDependenciesMeta": {
     "react-dom": {
       "optional": true
     },
     "react-native": {
+      "optional": true
+    },
+    "@types/loadable__component": {
       "optional": true
     }
   }

--- a/src/core/lazily.ts
+++ b/src/core/lazily.ts
@@ -14,11 +14,13 @@ export type LazyComponents<T extends {}> = Pick<
   // using Pick here instead of using key remapping directly preserves the reference to the original component
   // so you can Cmd/Ctrl + click on the imported component to jump to its definition
   // unfortunately key remapping seems to lose this context, which is worse DX
-  ComponentKeys<T>
+  //
+  // we intersect with string because we're filtering out symbol keys in our get trap
+  ComponentKeys<T> & string
 >
 
 export const lazily = <T extends {}>(
-  loader: (x: keyof LazyComponents<T> & string) => Promise<T>
+  loader: (x: keyof LazyComponents<T>) => Promise<T>
 ) =>
   new Proxy({} as LazyComponents<T>, {
     get: (target, componentName) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { lazily } from './core/lazily'
+export type { LazyComponents } from './core/lazily'

--- a/src/loadable.ts
+++ b/src/loadable.ts
@@ -1,1 +1,2 @@
 export { loadable } from './loadable/loadable'
+export type { LoadableComponents } from './loadable/loadable'

--- a/src/loadable/loadable.ts
+++ b/src/loadable/loadable.ts
@@ -16,7 +16,7 @@ export type LoadableComponents<T extends {}> = Pick<
       : never
   },
   // see core for why we use Pick here
-  ComponentKeys<T>
+  ComponentKeys<T> & string
 >
 
 // see https://loadable-components.com/docs/babel-plugin/#loadable-detection

--- a/src/loadable/loadable.ts
+++ b/src/loadable/loadable.ts
@@ -1,15 +1,33 @@
-// @ts-ignore does not provide TypeScript definitions
-import load from '@loadable/component'
+import load, {
+  OptionsWithoutResolver,
+  LoadableComponent,
+} from '@loadable/component'
+import { ComponentType, ComponentProps } from 'react'
+import { ComponentKeys } from '../util/types'
+
+/**
+ * Map a module to an object of loadable components.
+ * Non-component keys will be filtered out.
+ */
+export type LoadableComponents<T extends {}> = Pick<
+  {
+    [K in keyof T]: T[K] extends ComponentType<any>
+      ? LoadableComponent<ComponentProps<T[K]>>
+      : never
+  },
+  // see core for why we use Pick here
+  ComponentKeys<T>
+>
 
 // see https://loadable-components.com/docs/babel-plugin/#loadable-detection
-export const loadable = <T extends {}, U extends keyof T>(
+export const loadable = <T extends {}>(
   loader: () => Promise<T>,
-  opts?: any
+  opts?: OptionsWithoutResolver<any>
 ) =>
-  new Proxy(({} as unknown) as T, {
-    get: (target, componentName: U) => {
+  new Proxy({} as LoadableComponents<T>, {
+    get: (target, componentName) => {
       if (typeof componentName === 'string') {
-        return load(() => loader().then((x) => x[componentName]), opts)
+        return load(() => loader().then((x) => x[componentName as never]), opts)
       }
     },
   })

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,8 @@
+import type { ComponentType } from 'react'
+
+/**
+ * Extract the keys of an object that are valid React components
+ */
+export type ComponentKeys<T> = {
+  [K in keyof T]: T[K] extends ComponentType<any> ? K : never
+}[keyof T]

--- a/tests/lazily.test.tsx
+++ b/tests/lazily.test.tsx
@@ -3,8 +3,8 @@ import { fireEvent, render } from '@testing-library/react'
 import { lazily } from '../src/index'
 
 it('Shows loading for some random component', async () => {
-  const f = jest.fn()
-  const { Component } = lazily(() => new Promise((r) => f(r)))
+  const f = jest.fn(async () => ({ Component: () => <>Hello</> }))
+  const { Component } = lazily(f)
 
   const App: React.FC = () => {
     const [open, setOpen] = React.useReducer(() => true, false)
@@ -27,4 +27,6 @@ it('Shows loading for some random component', async () => {
   await findByText('Loading...')
 
   expect(f).toBeCalledTimes(1)
+
+  await findByText('Hello')
 })

--- a/tests/lazily.test.tsx
+++ b/tests/lazily.test.tsx
@@ -27,6 +27,7 @@ it('Shows loading for some random component', async () => {
   await findByText('Loading...')
 
   expect(f).toBeCalledTimes(1)
+  expect(f).toBeCalledWith('Component')
 
   await findByText('Hello')
 })

--- a/tests/loadable.test.tsx
+++ b/tests/loadable.test.tsx
@@ -3,8 +3,8 @@ import { fireEvent, render } from '@testing-library/react'
 import { loadable } from '../src/loadable'
 
 it('Shows loading for some random component', async () => {
-  const f = jest.fn()
-  const { Component } = loadable(() => new Promise((r) => f(r)), {
+  const f = jest.fn(async () => ({ Component: () => <>Hello</> }))
+  const { Component } = loadable(f, {
     fallback: 'Loading...',
   })
 
@@ -19,4 +19,6 @@ it('Shows loading for some random component', async () => {
   await findByText('Loading...')
 
   expect(f).toBeCalledTimes(1)
+
+  await findByText('Hello')
 })

--- a/tests/loadable.test.tsx
+++ b/tests/loadable.test.tsx
@@ -5,7 +5,7 @@ import { loadable } from '../src/loadable'
 it('Shows loading for some random component', async () => {
   const f = jest.fn(async () => ({ Component: () => <>Hello</> }))
   const { Component } = loadable(f, {
-    fallback: 'Loading...',
+    fallback: <>Loading...</>,
   })
 
   const App: React.FC = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,6 +1301,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/loadable__component@^5.13.0":
+  version "5.13.9"
+  resolved "https://registry.yarnpkg.com/@types/loadable__component/-/loadable__component-5.13.9.tgz#4a265ee0892ab3e52ca74ac98189f791a24f075b"
+  integrity sha512-QWOtIkwZqHNdQj3nixQ8oyihQiTMKZLk/DNuvNxMSbTfxf47w+kqcbnxlUeBgAxdOtW0Dh48dTAIp83iJKtnrQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/node@*":
   version "14.14.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.9.tgz#04afc9a25c6ff93da14deabd65dc44485b53c8d6"


### PR DESCRIPTION
Hi! Big fan of this package, have recommended it a few times and used it in some example apps :)

I wanted to help out and tweak the types to hopefully improve the experience for users.

The changes in this PR:

- Filters out non-component keys of the module, so they're not suggested
- Adds an optional peer dependency on the types package for loadable components (`@types/loadable__component`)
- Maps components to the correct wrapper types (LazyExoticComponent/LoadableComponent, respectively)
- Correctly types the parameter passed to lazily's loader as only the keys allows to be accessed (it also adds an assertion in the tests to make sure this is actually passed)

I've bumped to 0.10 as some of the changes here could be potentially breaking to users:

- Non-component keys now aren't allowed to be accessed (this shouldn't be an issue as the runtime behaviour for this wouldn't have made sense anyway)
- The wrapper types are written in a way that will likely break generic components. This seems unlikely to be an issue for most to me, but the workaround would just be to cast back to the original type:
```ts
const { Select } = lazily(() => import("my-select")) as unknown as typeof import("my-select");
```

Let me know what you think :)